### PR TITLE
Fix image rules.

### DIFF
--- a/cookbooks/image_build.yml
+++ b/cookbooks/image_build.yml
@@ -15,7 +15,6 @@ SHOULD:
   - All packages have a supplier
   - All packages have at least one externalRef
   # specific
-  - Main element has an arch qualifier purl
   - Number of packages is greater than 1
   - RPM packages have packageFileName
 rulesets:

--- a/cookbooks/image_release.yml
+++ b/cookbooks/image_release.yml
@@ -16,7 +16,6 @@ SHOULD:
   - All packages have a supplier
   - All packages have at least one externalRef
   # specific
-  - Main element has an arch qualifier purl
   - RPM packages have packageFileName
   - All Image PURLs contain qualifier repository_url and tag
 rulesets:

--- a/rulesets/implementations/specific/spdx23.py
+++ b/rulesets/implementations/specific/spdx23.py
@@ -41,7 +41,7 @@ def image_packages_variants(doc: dict):
                 and x.get("spdxElementId") == package["SPDXID"]
                 and x.get("relatedSpdxElement") in main_package_SPDXIDs,
                 doc.get("relationships", []),
-            )
+            ), None
         ), f"Package {package["SPDXID"]} is not variant of main element."
 
 

--- a/rulesets/specific.yml
+++ b/rulesets/specific.yml
@@ -26,10 +26,10 @@ rules:
         checker:
           func_name: image_packages_variants
   - name: All non-main image packages have an arch qualifier purl
-    failureMessage: Add arch qualifier to purls of packages.
+    failureMessage: Add arch qualifier to at least one purl of each package.
     implementations:
       - name: spdx23
-        fieldPath: packages[SPDXID!=${root_element_spdxids},SPDXID=${image_package_spdxids}]externalRefs[referenceType=purl]referenceLocator
+        fieldPath: packages[SPDXID!=${root_element_spdxids},SPDXID=${image_package_spdxids}]externalRefs[|,referenceType=purl]referenceLocator
         checker:
           str_contains: arch=
   - name: The SPDXID for non-main image packages be in the format SPDXRef-type-name-digest
@@ -40,13 +40,6 @@ rules:
         checker:
           str_matches_regex: 'SPDXRef-[a-z]+-[\w]+-[a-z0-9]+'
   # IMAGES
-  - name: Main element has an arch qualifier purl
-    failureMessage: Add arch qualifier to main element.
-    implementations:
-      - name: spdx23
-        fieldPath: packages[SPDXID=${root_element_spdxids},SPDXID=${image_package_spdxids}]externalRefs[referenceType=purl]referenceLocator
-        checker:
-          str_contains: arch=
   - name: All Image PURLs contain qualifier repository_url and tag
     failureMessage: Add qualifiers repository_url and tag to every PURL.
     implementations:


### PR DESCRIPTION
This PR fixes some rules related to Images in SPDX2.3 along with a slight querying refactor. Now the special queries `&` and `|` are able to accompany other filtering rules.